### PR TITLE
[WIP] Add standard and 360° images

### DIFF
--- a/lib/res/handlers/image.js
+++ b/lib/res/handlers/image.js
@@ -1,0 +1,35 @@
+class Video {
+	constructor(id) {
+		/** The index / ID of this object. Same as the marker id  */
+		this.id = id
+        
+		/**
+         * Displays an image
+         * @param {String} img The image that you want to display
+         */
+		this.loadImg = this.loadImage
+	}
+    
+	/**
+     * Displays an image
+     * @param {String} img The image that you want to display
+     */
+	loadImage(img) {
+		/** The location of the image */
+		this.img = img
+	}
+    
+	build() {
+		this.newJson.contentType = 'img'
+		this.newJson.videoData = {
+			id: this.id,
+			img: this.img
+		}
+	}
+    
+	getLocalFuncs() {
+		return ['build', 'loadImage', 'loadImg']
+	}
+}
+
+module.exports = Video


### PR DESCRIPTION
Fixes #38 

# API
The api for both will be identical, you set the type to `image` or `image360`. Then `loadImage` or its shortening `loadImg` can be used to load an image

```js
app.get(4, res => {
  res.type('image')
  res.loadImage('img/normalImage.png')
  res.send()
})

app.get(5, res => {
  res.type('image360')
  res.loadImg('img/360img.png')
  res.send()
})
```